### PR TITLE
Add Android feed-test app with lazy list API rendering

### DIFF
--- a/feed-test/app/build.gradle
+++ b/feed-test/app/build.gradle
@@ -1,0 +1,63 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.feedtest'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.feedtest"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.1'
+    }
+}
+
+dependencies {
+    // Compose BOM
+    implementation platform('androidx.compose:compose-bom:2024.02.00')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.material3:material3'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    // Activity
+    implementation 'androidx.activity:activity-compose:1.8.2'
+
+    // ViewModel
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+
+    // Retrofit + Gson
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+
+    // Coroutines
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+}

--- a/feed-test/app/src/main/AndroidManifest.xml
+++ b/feed-test/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.FeedTest"
+        android:supportsRtl="true">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+    </application>
+
+</manifest>

--- a/feed-test/app/src/main/java/com/example/feedtest/MainActivity.kt
+++ b/feed-test/app/src/main/java/com/example/feedtest/MainActivity.kt
@@ -1,0 +1,18 @@
+package com.example.feedtest
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import com.example.feedtest.ui.PostScreen
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                PostScreen()
+            }
+        }
+    }
+}

--- a/feed-test/app/src/main/java/com/example/feedtest/data/ApiService.kt
+++ b/feed-test/app/src/main/java/com/example/feedtest/data/ApiService.kt
@@ -1,0 +1,22 @@
+package com.example.feedtest.data
+
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+
+interface ApiService {
+    @GET("posts")
+    suspend fun getPosts(): List<Post>
+}
+
+object RetrofitClient {
+    private const val BASE_URL = "https://jsonplaceholder.typicode.com/"
+
+    val instance: ApiService by lazy {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ApiService::class.java)
+    }
+}

--- a/feed-test/app/src/main/java/com/example/feedtest/data/Post.kt
+++ b/feed-test/app/src/main/java/com/example/feedtest/data/Post.kt
@@ -1,0 +1,8 @@
+package com.example.feedtest.data
+
+data class Post(
+    val id: Int,
+    val userId: Int,
+    val title: String,
+    val body: String
+)

--- a/feed-test/app/src/main/java/com/example/feedtest/ui/PostScreen.kt
+++ b/feed-test/app/src/main/java/com/example/feedtest/ui/PostScreen.kt
@@ -1,0 +1,98 @@
+package com.example.feedtest.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.feedtest.data.Post
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostScreen(viewModel: PostViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Posts Feed") })
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when (val state = uiState) {
+                is PostsUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                is PostsUiState.Success -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp)
+                    ) {
+                        items(state.posts, key = { it.id }) { post ->
+                            PostCard(post)
+                        }
+                    }
+                }
+                is PostsUiState.Error -> {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(text = "Error: ${state.message}")
+                        Button(onClick = { viewModel.fetchPosts() }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PostCard(post: Post) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "#${post.id} ${post.title}",
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = post.body,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 4.dp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/feed-test/app/src/main/java/com/example/feedtest/ui/PostViewModel.kt
+++ b/feed-test/app/src/main/java/com/example/feedtest/ui/PostViewModel.kt
@@ -1,0 +1,36 @@
+package com.example.feedtest.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.feedtest.data.Post
+import com.example.feedtest.data.RetrofitClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+sealed class PostsUiState {
+    object Loading : PostsUiState()
+    data class Success(val posts: List<Post>) : PostsUiState()
+    data class Error(val message: String) : PostsUiState()
+}
+
+class PostViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow<PostsUiState>(PostsUiState.Loading)
+    val uiState: StateFlow<PostsUiState> = _uiState
+
+    init {
+        fetchPosts()
+    }
+
+    fun fetchPosts() {
+        _uiState.value = PostsUiState.Loading
+        viewModelScope.launch {
+            try {
+                val posts = RetrofitClient.instance.getPosts()
+                _uiState.value = PostsUiState.Success(posts)
+            } catch (e: Exception) {
+                _uiState.value = PostsUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+}

--- a/feed-test/app/src/main/res/values/strings.xml
+++ b/feed-test/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">FeedTest</string>
+</resources>

--- a/feed-test/app/src/main/res/values/themes.xml
+++ b/feed-test/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.FeedTest" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/feed-test/build.gradle
+++ b/feed-test/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'com.android.application' version '8.2.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
+}

--- a/feed-test/gradle.properties
+++ b/feed-test/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/feed-test/settings.gradle
+++ b/feed-test/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "FeedTest"
+include ':app'


### PR DESCRIPTION
Jetpack Compose app that fetches posts from JSONPlaceholder API
and displays them in a LazyColumn. Uses Retrofit for networking,
StateFlow + ViewModel for state management, and Material3 for UI.

https://claude.ai/code/session_01GbEMZ43F94g4UteV8tpzVf